### PR TITLE
Actual programmatic configuration of flux-dev and flux-schnell.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ trained_model.tar
 __*.zip
 **-cache
 model-cache
+
+cog.yaml

--- a/README.md
+++ b/README.md
@@ -1,42 +1,16 @@
-# FLUX
+# FLUX (in cog!)
 
-## Introduction
+This is a repository for running flux-dev and flux-schnell within a cog container. 
 
-Flux is a rectified flow transformer.
+## How to use this repo
 
-## Installation
+### Selecting a model
 
-Install via
+run `script/select.sh (dev,schnell)` and that'll create a cog.yaml configured for the appropriate model.
 
-```bash
-python3.10 -m venv .venv
-source .venv/bin/activate
-pip install -e '.[all]'
-```
+### Pushing a model
 
-### Models
+run `script/push.sh (dev,schnell)` to push the model to Replicate. Note that these models are currently configured
+to push to replicate internal repos. 
 
-We are offering three models:
-- `flux-schnell` step-distilled variant (quantized and non-quantized)
-- `flux-dev` guidance-distilled variant (quantized and non-quantized)
-- `flux-pro` the base model, available via API
-
-## Usage
-
-For interactive sampling run
-```bash
-python -m flux --name <name> --loop
-```
-Or to generate a single sample run
-```bash
-python -m flux --name <name> \
-  --height <height> --width <width> \
-  --prompt "<prompt>"
-```
-
-To use the quantized model, add the flag `--quantize_flow` to the above commands.
-
-Run the streamlit demo via
-```bash
-streamlit run demo_st.py
-```
+To push all models, run `script/cog-push-all.sh`

--- a/cog.yaml.template
+++ b/cog.yaml.template
@@ -27,6 +27,3 @@ build:
     - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/download/v0.8.2/pget_linux_x86_64" && chmod +x /usr/local/bin/pget
     - --mount=type=cache,target=/root/.cache/pip pip install cog==0.10.0a16
     - ln -sf $(which echo) $(which pip) 
-
-# predict.py defines how predictions are run on your model
-predict: "predict.py:Predictor"

--- a/script/cog-push-all.sh
+++ b/script/cog-push-all.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./script/push.sh dev
+./script/push.sh schnell

--- a/script/push.sh
+++ b/script/push.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
-cog push r8.im/replicate/flux-schnell-setup
-date +"%Y-%m-%d %H:%M:%S" > the_time.txt
-yolo push -e FLUX_MODEL=FLUX_DEV --base r8.im/replicate/flux-schnell-setup --dest r8.im/replicate/flux-dev-setup the_time.txt
+./script/select.sh "$1"
+if [ $? -ne 0 ]; then
+    echo "Couldn't select a model, double check you're passing a valid name."
+    exit 1
+fi
+
+v=$(cog --version)
+
+# async cog?
+if [[ $v == *"0.10.0"* ]]; then
+    echo "Async cog found, pushing model"
+else
+    echo "Nope! switch to async cog and rebuild"
+    exit -1
+fi
+
+cog push r8.im/replicate-internal/flux-$1-internal-model

--- a/script/select.sh
+++ b/script/select.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat cog.yaml.template > cog.yaml
+cat model-cog-configs/$1.yaml >> cog.yaml


### PR DESCRIPTION
It was getting a bit clunky setting up flux-dev and flux-schnell separately, so I wrote some quick scripts to tie them all together - now deploying is as simple as running a bash script. 

still need to set up updating the deployments, through CI/CD though. That will come soon. 