### PR TITLE
Disable fp8

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -115,6 +115,7 @@ class Predictor(BasePredictor):
         flow_model_name: str,
         compile_fp8: bool = False,
         compile_bf16: bool = False,
+        disable_fp8: bool = False,
     ) -> None:
         self.flow_model_name = flow_model_name
         print(f"Booting model {self.flow_model_name}")
@@ -165,14 +166,15 @@ class Predictor(BasePredictor):
         shared_models = LoadedModels(
             flow=None, ae=self.ae, clip=self.clip, t5=self.t5, config=None
         )
+        self.disable_fp8 = disable_fp8
+        if not disable_fp8:
+            self.fp8_pipe = FluxPipeline.load_pipeline_from_config_path(
+                f"fp8/configs/config-1-{flow_model_name}-h100.json",
+                shared_models=shared_models,
+            )
 
-        self.fp8_pipe = FluxPipeline.load_pipeline_from_config_path(
-            f"fp8/configs/config-1-{flow_model_name}-h100.json",
-            shared_models=shared_models,
-        )
-
-        if compile_fp8:
-            self.compile_fp8()
+            if compile_fp8:
+                self.compile_fp8()
 
         if compile_bf16:
             self.compile_bf16()
@@ -480,7 +482,7 @@ class SchnellPredictor(Predictor):
     ) -> List[Path]:
         hws_kwargs = self.preprocess(aspect_ratio, seed, megapixels)
 
-        if go_fast:
+        if go_fast and not self.disable_fp8:
             imgs, np_imgs = self.fp8_predict(
                 prompt,
                 num_outputs,
@@ -488,6 +490,8 @@ class SchnellPredictor(Predictor):
                 **hws_kwargs,
             )
         else:
+            if self.disable_fp8:
+                print("running bf16 model, fp8 disabled")
             imgs, np_imgs = self.base_predict(
                 prompt,
                 num_outputs,
@@ -544,7 +548,7 @@ class DevPredictor(Predictor):
             go_fast = False
         hws_kwargs = self.preprocess(aspect_ratio, seed, megapixels)
 
-        if go_fast:
+        if go_fast and not self.disable_fp8:
             imgs, np_imgs = self.fp8_predict(
                 prompt,
                 num_outputs,
@@ -555,6 +559,8 @@ class DevPredictor(Predictor):
                 **hws_kwargs,
             )
         else:
+            if self.disable_fp8:
+                print("running bf16 model, fp8 disabled")
             imgs, np_imgs = self.base_predict(
                 prompt,
                 num_outputs,

--- a/predict.py
+++ b/predict.py
@@ -169,7 +169,7 @@ class Predictor(BasePredictor):
 
         # fp8 only works w/compute capability >= 8.9
         self.disable_fp8 = disable_fp8 or torch.cuda.get_device_capability() < (8, 9)
-        
+
         if not self.disable_fp8:
             self.fp8_pipe = FluxPipeline.load_pipeline_from_config_path(
                 f"fp8/configs/config-1-{flow_model_name}-h100.json",

--- a/predict.py
+++ b/predict.py
@@ -147,8 +147,8 @@ class Predictor(BasePredictor):
         # need > 48 GB of ram to store all models in VRAM
         self.offload = "A40" in gpu_name
 
-        # if we're offloading then we're not on an H100; disable fp8. 
-        self.disable_fp8 = disable_fp8 or self.offload
+        # fp8 only works on H100 and l40s atm. 
+        self.disable_fp8 = disable_fp8 or ("H100" not in gpu_name and "L40S" not in gpu_name)
 
         device = "cuda"
         max_length = 256 if self.flow_model_name == "flux-schnell" else 512


### PR DESCRIPTION
Disabling fp8 compilation & `go_fast` for GPUs that don't support `_scaled_mm` - which is all GPUs w/compute capability < 8.9. 

This way folks can still pull and run the model w/o issue. Defaulting to just running the model slow if a user attempts to run the fast model on the wrong GPU for ease of use. 