### PR TITLE
document that outputs are not deterministic when `go_fast` is enabled

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -132,7 +132,7 @@ class Inputs:
     @staticmethod
     def go_fast_with_default(default: bool) -> Input:
         return Input(
-            description="Run faster predictions with model optimized for speed (currently fp8 quantized); disable to run in original bf16",
+            description="Run faster predictions with model optimized for speed (currently fp8 quantized); disable to run in original bf16. Note that outputs will not be deterministic when this is enabled, even if you set a seed.",
             default=default,
         )
 


### PR DESCRIPTION
![Screenshot 2024-11-15 at 09 57 03](https://github.com/user-attachments/assets/9504c792-acc5-44a9-af19-39fd9d3d2ff5)
