### PR TITLE
loading loras w/o mlp fine tune

### DIFF
--- a/safe-push-configs/dev-lora.yaml
+++ b/safe-push-configs/dev-lora.yaml
@@ -95,6 +95,17 @@ predict:
         lora_scale: 0.9
       match_prompt: A drawing of a man thinking about an oven
 
+    # non-replicate weights no mlp trained
+    - inputs:
+        prompt: photo of a boy ANIMESTYLE
+        num_outputs: 1
+        num_inference_steps: 28
+        guidance_scale: 3.5
+        output_format: jpg
+        go_fast: true
+        lora_weights: https://storage.googleapis.com/replicate-models-public-test/flux-loras/fixed_lora.safetensors
+        lora_scale: 0.9
+      match_prompt: An anime drawing of a boy
 
   fuzz:
     fixed_inputs:

--- a/safe-push-configs/schnell-lora.yaml
+++ b/safe-push-configs/schnell-lora.yaml
@@ -87,6 +87,17 @@ predict:
         lora_scale: 0.9
       match_prompt: A drawing of a man thinking about an oven
 
+    # non-replicate weights no mlp trained
+    - inputs:
+        prompt: photo of a boy ANIMESTYLE
+        num_outputs: 1
+        num_inference_steps: 4
+        output_format: jpg
+        go_fast: true
+        lora_weights: https://storage.googleapis.com/replicate-models-public-test/flux-loras/fixed_lora.safetensors
+        lora_scale: 0.9
+      match_prompt: An anime drawing of a boy
+
   fuzz:
     fixed_inputs:
       lora_weights:  huggingface.co/multimodalart/flux-tarot-v1


### PR DESCRIPTION
slightly different approach to #57 - currently only failure case is that some loras don't have the mlp layer tuned, so this creates a no-op mlp layer and adds that to the qkv_mlp weights. 

note that mlp lora_B has different dimensions than all other qkv/mlp loras. 