### PR TITLE
bump to torch 2.5.1, keeping cudnn attention

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install Cog
       run: |
-        sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/download/v0.9.21/cog_$(uname -s)_$(uname -m)"
+        sudo curl -o /usr/local/bin/cog -L "https://github.com/replicate/cog/releases/download/v0.11.6/cog_$(uname -s)_$(uname -m)"
         sudo chmod +x /usr/local/bin/cog
 
     - name: cog login

--- a/cog.yaml.template
+++ b/cog.yaml.template
@@ -22,7 +22,7 @@ build:
     - "loguru==0.7.2"
     - "pybase64==1.4.0"
     - "pydash==8.0.3"
-    - "opencv-python==4.10.0.84"
+    - "opencv-python-headless==4.10.0.84"
     - "torch==2.5.1"
     - "torchaudio==2.5.1"
     - "torchvision==0.20.1"

--- a/cog.yaml.template
+++ b/cog.yaml.template
@@ -23,13 +23,9 @@ build:
     - "pybase64==1.4.0"
     - "pydash==8.0.3"
     - "opencv-python==4.10.0.84"
-    # pinning to specific nightlies for release
-    - "https://download.pytorch.org/whl/nightly/cu124/torch-2.6.0.dev20240918%2Bcu124-cp311-cp311-linux_x86_64.whl"
-    - "https://download.pytorch.org/whl/nightly/cu124/torchaudio-2.5.0.dev20240918%2Bcu124-cp311-cp311-linux_x86_64.whl"
-    - "https://download.pytorch.org/whl/nightly/cu124/torchvision-0.20.0.dev20240918%2Bcu124-cp311-cp311-linux_x86_64.whl"
-    - "https://download.pytorch.org/whl/nightly/pytorch_triton-3.1.0%2B5fe38ffd73-cp311-cp311-linux_x86_64.whl"
+    - "torch==2.5.1"
+    - "torchaudio==2.5.1"
+    - "torchvision==0.20.1"
 
-
-  # commands run after the environment is setup
   run:
     - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/download/v0.8.2/pget_linux_x86_64" && chmod +x /usr/local/bin/pget

--- a/fp8/modules/flux_model.py
+++ b/fp8/modules/flux_model.py
@@ -17,6 +17,7 @@ import math
 from torch import Tensor, nn
 from pydantic import BaseModel
 from torch.nn import functional as F
+from torch.nn.attention import sdpa_kernel, SDPBackend
 
 
 class FluxParams(BaseModel):
@@ -38,7 +39,8 @@ class FluxParams(BaseModel):
 # @torch.compile(mode="reduce-overhead", fullgraph=True, disable=DISABLE_COMPILE)
 def attention(q: Tensor, k: Tensor, v: Tensor, pe: Tensor) -> Tensor:
     q, k = apply_rope(q, k, pe)
-    x = F.scaled_dot_product_attention(q, k, v).transpose(1, 2)
+    with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+        x = F.scaled_dot_product_attention(q, k, v).transpose(1, 2)
     x = x.reshape(*x.shape[:-2], -1)
     return x
 

--- a/predict.py
+++ b/predict.py
@@ -488,7 +488,8 @@ class Predictor(BasePredictor):
 
         timesteps = get_schedule(
             num_inference_steps,
-            (x.shape[-1] * x.shape[-2]) // 4, # equivalent to inp["img"].shape[1], needs to be here for prompt strength in img2img
+            # equivalent to inp["img"].shape[1], needs to be here for prompt strength in img2img
+            (x.shape[-1] * x.shape[-2]) // 4,
             shift=self.shift,
         )
 


### PR DESCRIPTION
Background: 
Getting us off of torch nightlies and onto torch 2.5.1; some of the optimizations we're doing for fast images don't play well with nightlies. 

Changes: 
- Need to add the SDPBackend CuDNN context manager b/c of [this change](https://github.com/pytorch/pytorch/pull/138522) in 2.5.1. 
- moved from installing opencv to opencv-headless; we don't need a gui. 
- fixed an issue w/how we're calculating timesteps that popped up when evaluating quality

Testing:
- latency is unimpacted