### PR TITLE
Extra lora fix

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -389,7 +389,7 @@ class Predictor(BasePredictor):
             lora_scale = lora_scale * self.fp8_lora_scale_multiplier
             cur_scale = self.fp8_lora_scale
             cur_extra_lora = self.fp8_extra_lora
-            cur_extra_lora_scale = extra_lora_scale 
+            cur_extra_lora_scale = self.fp8_extra_lora_scale 
 
             self.fp8_lora = LOADING
             self.fp8_extra_lora = LOADING

--- a/predict.py
+++ b/predict.py
@@ -376,9 +376,11 @@ class Predictor(BasePredictor):
         extra_lora_weights: str | None = None,
         extra_lora_scale: float = 1.0,
     ):
-        LOADING = "loading"
+        loading = "loading"
         if not lora_weights and extra_lora_weights:
-            print(f"extra_lora_weights {extra_lora_weights} were found, and lora_weights were None! This shouldn't happen. Setting lora_weights to {extra_lora_weights} and lora_scale to extra_lora_scale: {extra_lora_scale} and running.")
+            print(
+                f"extra_lora_weights {extra_lora_weights} were found, and lora_weights were None! This shouldn't happen. Setting lora_weights to {extra_lora_weights} and lora_scale to extra_lora_scale: {extra_lora_scale} and running."
+            )
             lora_weights = extra_lora_weights
             lora_scale = extra_lora_scale
             extra_lora_weights = None
@@ -389,10 +391,10 @@ class Predictor(BasePredictor):
             lora_scale = lora_scale * self.fp8_lora_scale_multiplier
             cur_scale = self.fp8_lora_scale
             cur_extra_lora = self.fp8_extra_lora
-            cur_extra_lora_scale = self.fp8_extra_lora_scale 
+            cur_extra_lora_scale = self.fp8_extra_lora_scale
 
-            self.fp8_lora = LOADING
-            self.fp8_extra_lora = LOADING
+            self.fp8_lora = loading
+            self.fp8_extra_lora = loading
 
         else:
             model = self.flux
@@ -401,8 +403,8 @@ class Predictor(BasePredictor):
             cur_extra_lora = self.bf16_extra_lora
             cur_extra_lora_scale = self.bf16_extra_lora_scale
 
-            self.bf16_lora = LOADING
-            self.bf16_extra_lora = LOADING
+            self.bf16_lora = loading
+            self.bf16_extra_lora = loading
 
         if lora_weights:
             # since we merge weights, need to reload for change in scale. auto-reloading for extra weights
@@ -427,7 +429,7 @@ class Predictor(BasePredictor):
             else:
                 print(f"Lora {lora_weights} already loaded")
                 if extra_lora_weights:
-                    print(F"Extra lora {extra_lora_weights} already loaded")
+                    print(f"Extra lora {extra_lora_weights} already loaded")
 
         elif cur_lora:
             unload_loras(model)

--- a/predict.py
+++ b/predict.py
@@ -377,6 +377,11 @@ class Predictor(BasePredictor):
         extra_lora_scale: float = 1.0,
     ):
         LOADING = "loading"
+        if not lora_weights and extra_lora_weights:
+            print(f"extra_lora_weights {extra_lora_weights} were found, and lora_weights were None! This shouldn't happen. Setting lora_weights to {extra_lora_weights} and lora_scale to extra_lora_scale: {extra_lora_scale} and running.")
+            lora_weights = extra_lora_weights
+            lora_scale = extra_lora_scale
+            extra_lora_weights = None
 
         if go_fast:
             model = self.fp8_pipe.model

--- a/predict.py
+++ b/predict.py
@@ -179,9 +179,13 @@ class Predictor(BasePredictor):
         self.weights_cache = WeightsDownloadCache()
         self.bf16_lora = None
         self.bf16_lora_scale = None
+        self.bf16_extra_lora = None
+        self.bf16_extra_lora_scale = None
         self.fp8_lora = None
         self.fp8_lora_scale = None
         self.fp8_lora_scale_multiplier = 1.5
+        self.fp8_extra_lora = None
+        self.fp8_extra_lora_scale = None
 
     def base_setup(
         self,
@@ -372,29 +376,38 @@ class Predictor(BasePredictor):
         extra_lora_weights: str | None = None,
         extra_lora_scale: float = 1.0,
     ):
+        LOADING = "loading"
+
         if go_fast:
             model = self.fp8_pipe.model
             cur_lora = self.fp8_lora
             lora_scale = lora_scale * self.fp8_lora_scale_multiplier
             cur_scale = self.fp8_lora_scale
+            cur_extra_lora = self.fp8_extra_lora
+            cur_extra_lora_scale = extra_lora_scale 
 
-            self.fp8_lora = "loading"
+            self.fp8_lora = LOADING
+            self.fp8_extra_lora = LOADING
 
         else:
             model = self.flux
             cur_lora = self.bf16_lora
             cur_scale = self.bf16_lora_scale
+            cur_extra_lora = self.bf16_extra_lora
+            cur_extra_lora_scale = self.bf16_extra_lora_scale
 
-            self.bf16_lora = "loading"
+            self.bf16_lora = LOADING
+            self.bf16_extra_lora = LOADING
 
         if lora_weights:
             # since we merge weights, need to reload for change in scale. auto-reloading for extra weights
             if (
                 lora_weights != cur_lora
                 or lora_scale != cur_scale
-                or extra_lora_weights
+                or extra_lora_weights != cur_extra_lora
+                or extra_lora_scale != cur_extra_lora_scale
             ):
-                if cur_lora:
+                if cur_lora or cur_extra_lora:
                     unload_loras(model)
                 lora_path = self.weights_cache.ensure(lora_weights)
                 if extra_lora_weights:
@@ -408,16 +421,23 @@ class Predictor(BasePredictor):
                     load_lora(model, lora_path, lora_scale)
             else:
                 print(f"Lora {lora_weights} already loaded")
+                if extra_lora_weights:
+                    print(F"Extra lora {extra_lora_weights} already loaded")
+
         elif cur_lora:
             unload_loras(model)
 
         if go_fast:
             self.fp8_lora = lora_weights
             self.fp8_lora_scale = lora_scale
+            self.fp8_extra_lora = extra_lora_weights
+            self.fp8_extra_lora_scale = extra_lora_scale
 
         else:
             self.bf16_lora = lora_weights
             self.bf16_lora_scale = lora_scale
+            self.bf16_extra_lora = extra_lora_weights
+            self.bf16_extra_lora_scale = extra_lora_scale
 
     def size_from_aspect_megapixels(
         self, aspect_ratio: str, megapixels: str = "1"


### PR DESCRIPTION
We have a bug right now in our hotswap loras where if a users passes a given `extra_lora` for a prediction, and then removes that `extra_lora` but otherwise doesn't change `lora_scale` or `replicate_weights`, the `extra_lora` will persist. 

Any change to `lora_scale`, `replicate_weights`, or adding a new `extra_lora` should reset the weights (assuming that request maps to the instance that has the `extra_lora` that's sticking around) - but still, this is the very definition of a weird, annoying bug.  

The fix below explicitly monitors for changes in extra_lora and handles it the same way that changes in lora_weights are handled. It also handles the case where `extra_lora_weights` are passed in and `lora_weights` aren't; this is an edge case, but good to handle. 