### PR TITLE
wip bf16 weight swapping

### DIFF
--- a/fp8/flux_pipeline.py
+++ b/fp8/flux_pipeline.py
@@ -27,7 +27,7 @@ import platform
 from torchvision.transforms import functional as TF
 from tqdm import tqdm
 
-import fp8.lora_loading as lora_loading
+import lora_loading as lora_loading
 from fp8.image_encoder import ImageEncoder
 from fp8.util import (
     LoadedModels,
@@ -156,7 +156,7 @@ class FluxPipeline:
             scale (float): Scaling factor for the LoRA weights.
 
         """
-        self.model = lora_loading.apply_lora_to_model(self.model, lora_path, scale)
+        self.model = lora_loading.apply_lora_to_model_and_store_clones(self.model, lora_path, scale)
 
     @torch.inference_mode()
     def compile(self):

--- a/lora_loading.py
+++ b/lora_loading.py
@@ -11,7 +11,6 @@ try:
 except Exception as e:
     CublasLinear = type(None)
 from fp8.float8_quantize import F8Linear
-from fp8.modules.flux_model import Flux
 
 
 class F8LinearClone:
@@ -21,6 +20,10 @@ class F8LinearClone:
         self.input_scale = module.input_scale
         self.scale_reciprocal = module.scale_reciprocal
         self.input_scale_reciprocal = module.input_scale_reciprocal
+
+class LinearClone: 
+    def __init__(self, module):
+        self.weight = module.weight.data
 
 
 def swap_scale_shift(weight):
@@ -353,7 +356,7 @@ def convert_from_original_flux_checkpoint(
 
 
 def get_module_for_key(
-    key: str, model: Flux
+    key: str, model: 'Flux'
 ) -> F8Linear | torch.nn.Linear | CublasLinear:
     parts = key.split(".")
     module = model
@@ -516,25 +519,27 @@ def convert_lora_weights(lora_path: str | Path, has_guidance: bool):
         )
     else:
         lora_weights = convert_from_original_flux_checkpoint(lora_weights)
-    logger.info("LoRA weights loaded")
     return lora_weights
 
 
 @torch.inference_mode()
-def load_loras(model: Flux, lora_paths: list[str] | list[Path], lora_scales: list[float]):
+def load_loras(model: 'Flux', lora_paths: list[str] | list[Path], lora_scales: list[float]):
     t = time.time()
     for lora, scale in zip(lora_paths, lora_scales):
         load_lora(model, lora, scale) 
 
 
 @torch.inference_mode()
-def load_lora(model: Flux, lora_path: str | Path, lora_scale: float = 1.0):
+def load_lora(model: 'Flux', lora_path: str | Path, lora_scale: float = 1.0):
     t = time.time()
+    if not hasattr(model, "weight_clones") or model.weight_clones is None:
+        model.weight_clones = {}
+
     has_guidance = model.params.guidance_embed
 
     lora_weights = convert_lora_weights(lora_path, has_guidance)
 
-    f8_clones = apply_lora_to_model(model, lora_weights, lora_scale)
+    apply_lora_to_model_and_store_clones(model, lora_weights, lora_scale)
 
     logger.success(f"LoRA applied in {time.time() - t:.2}s")
 
@@ -543,34 +548,51 @@ def load_lora(model: Flux, lora_path: str | Path, lora_scale: float = 1.0):
     else:
         model.lora_weights = [(lora_weights, lora_scale)]
 
-    if hasattr(model, "f8_clones") and f8_clones is not None and model.f8_clones is not None:
-        # for subsequent lora loads, we only add clones for new modules
-        for k in f8_clones.keys():
-            if k not in model.f8_clones:
-                model.f8_clones[k] = f8_clones[k]
-
-    else:
-        model.f8_clones = f8_clones
-
 
 @torch.inference_mode()
-def unload_loras(model: Flux):
+def unload_loras(model: 'Flux'):
     t = time.time()
     if not hasattr(model, "lora_weights") or not model.lora_weights:
         return
+    
+    # Get all unique keys that had LoRA weights applied
+    expected_keys = set()
+    for lora_weights, _ in model.lora_weights:
+        keys = set(key.replace(".lora_A.weight", "")
+                     .replace(".lora_B.weight", "")
+                     .replace(".alpha", "")
+                  for key in lora_weights.keys())
+        expected_keys.update(keys)
 
-    for lora_weights, lora_scale in model.lora_weights[::-1]:
-        apply_lora_to_model(model, lora_weights, -lora_scale, model.f8_clones)
+    # Check we have clones for all modules that had LoRA weights
+    assert expected_keys == set(model.weight_clones.keys()), \
+           f"Mismatch between LoRA keys and weight clones. Missing: {expected_keys - set(model.weight_clones.keys())}"
+    
+    for key, clone in model.weight_clones.items():
+        module = get_module_for_key(key, model)
+
+        if isinstance(module, F8Linear):
+            module.float8_data = clone.float8_data
+            module.scale = clone.scale
+            module.input_scale = clone.input_scale
+            module.scale_reciprocal = clone.scale_reciprocal
+            module.input_scale_reciprocal = clone.input_scale_reciprocal
+        else:
+            module.weight.data = clone.weight
+
     logger.success(f"LoRAs unloaded in {time.time() - t:.2}s")
+    logger.info(f"Unloaded {len(model.weight_clones.keys())} layers")
 
     model.lora_weights = []
-    model.f8_clones = None
+    model.weight_clones = {}
 
 
 @torch.inference_mode()
-def apply_lora_to_model(model: Flux, lora_weights: dict, lora_scale: float = 1.0, unload_f8_clones = None):
-    f8_clones = {}
-
+def apply_lora_to_model_and_store_clones(model: 'Flux', lora_weights: dict, lora_scale: float = 1.0):
+    """
+    Applies lora to model; clones and stores existing weights. 
+    Only clones weights that need to be cloned. 
+    """
     logger.debug("Extracting keys")
     keys_without_ab = [
         key.replace(".lora_A.weight", "")
@@ -585,60 +607,57 @@ def apply_lora_to_model(model: Flux, lora_weights: dict, lora_scale: float = 1.0
     for key in tqdm(keys_without_ab, desc="Applying LoRA", total=len(keys_without_ab)):
         module = get_module_for_key(key, model)
 
-        if unload_f8_clones and key in unload_f8_clones:
-            clone = unload_f8_clones[key]
-            module.float8_data = clone.float8_data
-            module.scale = clone.scale
-            module.input_scale = clone.input_scale
-            module.scale_reciprocal = clone.scale_reciprocal
-            module.input_scale_reciprocal = clone.input_scale_reciprocal
+        weight_is_f8 = isinstance(module, F8Linear)
+        if weight_is_f8:
+            if key not in model.weight_clones:
+                model.weight_clones[key] = F8LinearClone(module)
+
+            weight_f16 = (
+                module.float8_data.clone()
+                .float()
+                .mul(module.scale_reciprocal)
+                .to(module.weight.device)
+                .to(torch.bfloat16)
+            )
+        elif isinstance(module, torch.nn.Linear) or isinstance(module, CublasLinear):
+            if key not in model.weight_clones:
+                model.weight_clones[key] = LinearClone(module)
+            weight_f16 = module.weight.clone()
+        else:
+            raise Exception(f"Trying to load lora on module {key} that is not a linear layer")
+
+        lora_sd = get_lora_for_key(key, lora_weights)
+
+        assert weight_f16.dtype == torch.bfloat16, f"{key} is {weight_f16.dtype}, not torch.bfloat16"
+
+        if ".linear1" in key:
+            weight_f16 = apply_linear1_lora_weight_to_module(
+                weight_f16, lora_sd, lora_scale=lora_scale
+            )
+
+        elif "_attn.qkv" in key:
+            weight_f16 = apply_attn_qkv_lora_weight_to_module(
+                weight_f16, lora_sd, lora_scale=lora_scale
+            )
 
         else:
-            dtype = model.dtype if hasattr(model, "dtype") else torch.bfloat16
+            weight_f16 = apply_lora_weight_to_module(
+                weight_f16, lora_sd, lora_scale=lora_scale
+            )
 
-            weight_is_f8 = False
-            if isinstance(module, F8Linear):
-                f8_clones[key] = F8LinearClone(module)
+        assert weight_f16.dtype == torch.bfloat16, f"{key} is {weight_f16.dtype} after applying lora, not torch.bfloat16"
 
-                weight_is_f8 = True
-                weight_f16 = (
-                    module.float8_data.clone()
-                    .float()
-                    .mul(module.scale_reciprocal)
-                    .to(module.weight.device)
-                    .to(torch.bfloat16)
-                )
-            elif isinstance(module, torch.nn.Linear):
-                weight_f16 = module.weight.clone()  
-            elif isinstance(module, CublasLinear):
-                weight_f16 = module.weight.clone()  
-            lora_sd = get_lora_for_key(key, lora_weights)
+        if weight_is_f8:
+            module.set_weight_tensor(weight_f16)
+        else:
+            module.weight.data = weight_f16
+    
+    if weight_is_f8:
+        logger.info("Loading LoRA in fp8")
+    else:
+        logger.info("Loading LoRA in bf16")
 
-            assert weight_f16.dtype == torch.bfloat16, f"{key} is {weight_f16.dtype}, not torch.bfloat16"
-
-            if ".linear1" in key:
-                weight_f16 = apply_linear1_lora_weight_to_module(
-                    weight_f16, lora_sd, lora_scale=lora_scale
-                )
-
-            elif "_attn.qkv" in key:
-                weight_f16 = apply_attn_qkv_lora_weight_to_module(
-                    weight_f16, lora_sd, lora_scale=lora_scale
-                )
-
-            else:
-                weight_f16 = apply_lora_weight_to_module(
-                    weight_f16, lora_sd, lora_scale=lora_scale
-                )
-
-            assert weight_f16.dtype == torch.bfloat16, f"{key} is {weight_f16.dtype} after applying lora, not torch.bfloat16"
-
-            if weight_is_f8:
-                module.set_weight_tensor(weight_f16)
-            else:
-                module.weight.data = weight_f16
-
-    return f8_clones
+    return 
 
 # The utilities under `_convert_kohya_flux_lora_to_diffusers()`
 # are taken from https://github.com/kohya-ss/sd-scripts/blob/a61cf73a5cb5209c3f4d1a3688dd276a4dfd1ecb/networks/convert_flux_lora.py

--- a/predict.py
+++ b/predict.py
@@ -25,7 +25,7 @@ from flux.sampling import (
 )
 from fp8.flux_pipeline import FluxPipeline
 from fp8.util import LoadedModels
-from fp8.lora_loading import load_lora, load_loras, unload_loras
+from lora_loading import load_lora, load_loras, unload_loras
 
 import numpy as np
 from einops import rearrange

--- a/ruff.toml
+++ b/ruff.toml
@@ -28,6 +28,7 @@ exclude = [
     "venv",
     "flux/",
     "fp8/",
+    "lora_loading.py"
 ]
 
 # Same as Black.


### PR DESCRIPTION
This does a few things: 

- pulls unmerging functionality entirely out of `apply_lora_to_model` now that we aren't merging w/negative lora_scale
- moves `lora_loading.py` out of the `fp8` package and adds some logging to indicate that it serves both bf16 and fp8 codepaths