### PR TITLE
Adds Flux FIll LoRA

### DIFF
--- a/model-cog-configs/.ipynb_checkpoints/fill-dev-lora-checkpoint.yaml
+++ b/model-cog-configs/.ipynb_checkpoints/fill-dev-lora-checkpoint.yaml
@@ -1,0 +1,1 @@
+predict: "predict.py:FillDevPredictor"

--- a/model-cog-configs/fill-dev-lora.yaml
+++ b/model-cog-configs/fill-dev-lora.yaml
@@ -1,0 +1,1 @@
+predict: "predict.py:FillDevLoraPredictor"

--- a/safe-push-configs/fill-dev-lora.yaml
+++ b/safe-push-configs/fill-dev-lora.yaml
@@ -1,0 +1,15 @@
+model: replicate/flux-dev-fill-internal-model
+test_model: replicate/test-flux-dev-fill
+test_hardware: cpu
+predict:
+  compare_outputs: false
+  predict_timeout: 300
+  test_cases:
+
+    # basic
+    - inputs:
+        image: https://replicate.delivery/mgxm/f8c9cb3a-8ee8-41a7-9ef6-c65b37acc8af/desktop.png
+        mask: https://replicate.delivery/mgxm/188d0097-6a6f-4488-a058-b0b7a66e5677/desktop-mask.png
+        prompt: A herd of sheep grazing on a hill
+        seed: 2
+      match_prompt: An image of sheep grazing on a hill


### PR DESCRIPTION
After experimenting a bit with it, I've found that LoRAs trained on Flux Dev can also be used in Flux Fill with good results. This PR just adds the FluxFillLoRA model to the repo.  I guess the `safe-push-configs/fill-dev-lora.yaml` needs some modifications once you deploy a specific model for this version. 

Feel free to suggest modifications in order to merge the PR!  :) 