### PR TITLE
img2img resizing for diffusers predictor

### DIFF
--- a/diffusers_predictor.py
+++ b/diffusers_predictor.py
@@ -28,7 +28,7 @@ FLUX_DEV_PATH = "./model-cache/FLUX.1-dev"
 FLUX_SCHNELL_PATH = "./model-cache/FLUX.1-schnell"
 MODEL_CACHE = "./model-cache/"
 
-MAX_IMAGE_SIZE=1440
+MAX_IMAGE_SIZE = 1440
 
 
 @dataclass
@@ -228,7 +228,7 @@ class DiffusersFlux:
             if scale < 1:
                 width = int(width * scale)
                 height = int(height * scale)
-                
+
             # Calculate dimensions that are multiples of 16
             target_width = make_multiple_of_16(width)
             target_height = make_multiple_of_16(height)

--- a/diffusers_predictor.py
+++ b/diffusers_predictor.py
@@ -28,6 +28,8 @@ FLUX_DEV_PATH = "./model-cache/FLUX.1-dev"
 FLUX_SCHNELL_PATH = "./model-cache/FLUX.1-schnell"
 MODEL_CACHE = "./model-cache/"
 
+MAX_IMAGE_SIZE=1440
+
 
 @dataclass
 class FluxConfig:
@@ -217,9 +219,19 @@ class DiffusersFlux:
             input_image = Image.open(legacy_image_path).convert("RGB")
             original_width, original_height = input_image.size
 
+            width = original_width
+            height = original_height
+            print(f"Input image size: {width}x{height}")
+
+            # Calculate the scaling factor if the image exceeds max_image_size
+            scale = min(MAX_IMAGE_SIZE / width, MAX_IMAGE_SIZE / height, 1)
+            if scale < 1:
+                width = int(width * scale)
+                height = int(height * scale)
+                
             # Calculate dimensions that are multiples of 16
-            target_width = make_multiple_of_16(original_width)
-            target_height = make_multiple_of_16(original_height)
+            target_width = make_multiple_of_16(width)
+            target_height = make_multiple_of_16(height)
             target_size = (target_width, target_height)
 
             print(

--- a/predict.py
+++ b/predict.py
@@ -716,7 +716,7 @@ class FillDevPredictor(Predictor):
 
 
 class HotswapPredictor(Predictor):
-    def setup(self) -> None:
+    def setup(self, torch_compile=True) -> None:
         self.base_setup()
         shared_cache = WeightsDownloadCache()
 
@@ -740,7 +740,7 @@ class HotswapPredictor(Predictor):
         self.fp8_dev = BflFp8Flux(
             FLUX_DEV_FP8,
             shared_models_for_fp8,
-            torch_compile=True,
+            torch_compile=torch_compile,
             compilation_aspect_ratios=ASPECT_RATIOS,
             weights_download_cache=shared_cache,
             restore_lora_from_cloned_weights=True,
@@ -754,7 +754,7 @@ class HotswapPredictor(Predictor):
         self.fp8_schnell = BflFp8Flux(
             FLUX_SCHNELL_FP8,
             shared_models_for_fp8,
-            torch_compile=True,
+            torch_compile=torch_compile,
             compilation_aspect_ratios=ASPECT_RATIOS,
             weights_download_cache=shared_cache,
             restore_lora_from_cloned_weights=True,


### PR DESCRIPTION
Flux has quality issues generating images > 1440x1440; we have been resizing images to fit within that size for img2img, forgot to add it back to the diffusers predictor. this fixes that. 