### PR TITLE
Informative civit download

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -55,11 +55,6 @@ jobs:
     - name: Install cog-safe-push
       run: |
         pip install git+https://github.com/replicate/cog-safe-push.git
-    
-    - name: Create .env file
-      if: ${{ matrix.model == 'schnell-lora' || matrix.model == 'dev-lora' || matrix.model == 'hotswap-lora' || matrix.model == 'fill-dev'}}
-      run: |
-        echo "CIVITAI_API_KEY=${{ secrets.CIVITAI_API_KEY }}" > .env
 
     - name: Push selected models
       env:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -9,9 +9,31 @@ on:
         default: 'all'
 
 jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+        
+      - id: set-matrix
+        run: |
+          if [ "${{ inputs.models }}" = "all" ]; then
+            echo "matrix={\"model\":[\"schnell\",\"dev\",\"fill-dev\",\"canny-dev\",\"depth-dev\",\"redux-dev\",\"redux-schnell\",\"schnell-lora\",\"dev-lora\",\"hotswap-lora\"]}" >> $GITHUB_OUTPUT
+          else
+            # Convert comma-separated string to JSON array
+            MODELS=$(echo "${{ inputs.models }}" | jq -R -s -c 'split(",")')
+            echo "matrix={\"model\":$MODELS}" >> $GITHUB_OUTPUT
+          fi
+          
   cog-safe-push:
     # runs-on: ubuntu-latest-4-cores
+    needs: prepare-matrix
     runs-on: depot-ubuntu-22.04-4
+    strategy:
+      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
+      fail-fast: false  # Continue with other models if one fails
 
     steps:
     - uses: actions/checkout@v3
@@ -33,27 +55,24 @@ jobs:
     - name: Install cog-safe-push
       run: |
         pip install git+https://github.com/replicate/cog-safe-push.git
+    
+    - name: Create .env file
+      if: ${{ matrix.model == 'schnell-lora' || matrix.model == 'dev-lora' || matrix.model == 'hotswap-lora' || matrix.model == 'fill-dev'}}
+      run: |
+        echo "CIVITAI_API_KEY=${{ secrets.CIVITAI_API_KEY }}" > .env
 
     - name: Push selected models
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
       run: |
-        if [ "${{ inputs.models }}" = "all" ]; then
-          models="schnell,dev,fill-dev,canny-dev,depth-dev,redux-dev,redux-schnell,schnell-lora,dev-lora,hotswap-lora"
-        else
-          models="${{ inputs.models }}"
+        echo "==="
+        echo "==="
+        echo "=== Pushing ${{ matrix.model }}"
+        echo "==="
+        echo "==="
+        ./script/select.sh ${{ matrix.model }}
+        cog-safe-push -vv
+        if [ "${{ matrix.model }}" != "hotswap-lora" ]; then
+          cog push r8.im/black-forest-labs/flux-${{ matrix.model }}
         fi
-
-        for model in ${models//,/ }; do
-          echo "==="
-          echo "==="
-          echo "=== Pushing $model"
-          echo "==="
-          echo "==="
-          ./script/select.sh $model
-          cog-safe-push -vv
-          if [ "$model" != "hotswap-lora" ]; then
-            cog push r8.im/black-forest-labs/flux-$model  # to get openapi schema :..(
-          fi
-        done

--- a/weights.py
+++ b/weights.py
@@ -76,7 +76,9 @@ class WeightsDownloadCache:
 
 
 def download_weights(url: str, path: Path):
+    import pdb
     download_url = make_download_url(url)
+    pdb.set_trace()
     download_weights_url(download_url, path)
 
 
@@ -154,7 +156,7 @@ def download_data_url(url: str, path: Path):
 def download_safetensors(url: str, path: Path):
     try:
         # don't want to leak civitai api key
-        output_redirect = subprocess.PIPE if "token=" in url else None
+        output_redirect = subprocess.PIPE 
         result = subprocess.run(
             ["pget", url, str(path)],
             check=False,

--- a/weights.py
+++ b/weights.py
@@ -15,6 +15,10 @@ import requests
 
 DEFAULT_CACHE_BASE_DIR = Path("/src/weights-cache")
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 
 class WeightsDownloadCache:
     def __init__(
@@ -149,7 +153,26 @@ def download_data_url(url: str, path: Path):
 
 def download_safetensors(url: str, path: Path):
     try:
-        subprocess.run(["pget", url, str(path)], check=True)
+        # don't want to leak civitai api key
+        output_redirect = subprocess.PIPE if "token=" in url else None
+        result = subprocess.run(
+            ["pget", url, str(path)],
+            check=False,
+            stdout=output_redirect,
+            stderr=output_redirect,
+            text=True
+        )
+
+        if result.returncode != 0:
+            error_output = result.stderr or ""
+            if "401" in error_output:
+                raise RuntimeError("Authorization to download weights failed. Please check to see if an API key is needed and if so pass in with the URL.")
+            if "404" in error_output:
+                if "civitai" in url:
+                    raise RuntimeError("Model not found on CivitAI at that URL. Double check the CivitAI model ID; the id on the download link can be different than the id to browse to the model page.")
+                raise RuntimeError("Weights not found at the supplied URL. Please check the URL.")
+            raise RuntimeError(f"Failed to download safetensors file: {error_output}")
+
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to download safetensors file: {e}")
 
@@ -225,4 +248,8 @@ def make_huggingface_download_url(owner: str, model_name: str) -> str:
 
 
 def make_civitai_download_url(model_id: str) -> str:
-    return f"https://civitai.com/api/download/models/{model_id}?type=Model&format=SafeTensor"
+    civit_api_key = os.getenv("CIVITAI_API_KEY")
+    if civit_api_key is None:
+        return f"https://civitai.com/api/download/models/{model_id}?type=Model&format=SafeTensor"
+    print(f"downloading from CivitAI at https://civitai.com/api/download/models/{model_id}?type=Model&format=SafeTensor&token=****")
+    return f"https://civitai.com/api/download/models/{model_id}?type=Model&format=SafeTensor&token={civit_api_key}"

--- a/weights.py
+++ b/weights.py
@@ -157,7 +157,7 @@ def download_safetensors(url: str, path: Path):
         output_redirect = subprocess.PIPE
         if "token=" in url:
             # print url without token
-            print(f"downloading weights from {url.split("token=")[0]}token=***")
+            print(f"downloading weights from {url.split('token=')[0]}token=***")
         else:
             print(f"downloading weights from {url}")
 


### PR DESCRIPTION
We've had some users have issues w/civit downloads; the errors that happen when trying to download a model w/the wrong id or w/o auth from civit aren't immediately obvious. 

This change makes those errors much easier to interpret. 

it also, just for fun, parallelizes pushing models w/cog-safe-push for faster deploys. 