### PR TITLE
Support CivitAI and HF API Tokens for using LoRAs that require authentication

### DIFF
--- a/bfl_predictor.py
+++ b/bfl_predictor.py
@@ -97,9 +97,17 @@ class LoraMixin:
             ):
                 if self.lora or self.extra_lora:
                     unload_loras(model)
-                lora_path = self.weights_cache.ensure(lora_weights, hf_api_token=hf_api_token, civitai_api_token=civitai_api_token)
+                lora_path = self.weights_cache.ensure(
+                    lora_weights,
+                    hf_api_token=hf_api_token,
+                    civitai_api_token=civitai_api_token,
+                )
                 if extra_lora_weights:
-                    extra_lora_path = self.weights_cache.ensure(extra_lora_weights, hf_api_token=hf_api_token, civitai_api_token=civitai_api_token)
+                    extra_lora_path = self.weights_cache.ensure(
+                        extra_lora_weights,
+                        hf_api_token=hf_api_token,
+                        civitai_api_token=civitai_api_token,
+                    )
                     load_loras(
                         model,
                         [lora_path, extra_lora_path],

--- a/bfl_predictor.py
+++ b/bfl_predictor.py
@@ -66,6 +66,8 @@ class LoraMixin:
         lora_scale: float = 1.0,
         extra_lora_weights: str | None = None,
         extra_lora_scale: float = 1.0,
+        hf_api_token: str | None = None,
+        civitai_api_token: str | None = None,
     ):
         loading = "loading"
         if not lora_weights and extra_lora_weights:
@@ -95,9 +97,9 @@ class LoraMixin:
             ):
                 if self.lora or self.extra_lora:
                     unload_loras(model)
-                lora_path = self.weights_cache.ensure(lora_weights)
+                lora_path = self.weights_cache.ensure(lora_weights, hf_api_token=hf_api_token, civitai_api_token=civitai_api_token)
                 if extra_lora_weights:
-                    extra_lora_path = self.weights_cache.ensure(extra_lora_weights)
+                    extra_lora_path = self.weights_cache.ensure(extra_lora_weights, hf_api_token=hf_api_token, civitai_api_token=civitai_api_token)
                     load_loras(
                         model,
                         [lora_path, extra_lora_path],

--- a/predict.py
+++ b/predict.py
@@ -527,7 +527,7 @@ class DevLoraPredictor(Predictor):
         output_quality: int = Inputs.output_quality,
         disable_safety_checker: bool = Inputs.disable_safety_checker,
         go_fast: bool = Inputs.go_fast_with_default(True),
-        lora_weights: str  = Input(
+        lora_weights: str = Input(
             description="Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>/<lora-weights-file.safetensors>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet, including signed URLs. For example, 'fofr/flux-pixar-cars'. Civit AI and HuggingFace LoRAs may require an API token to access, which you can provide in the `civitai_api_token` and `hf_api_token` inputs respectively.",
             default=None,
         ),
@@ -557,7 +557,14 @@ class DevLoraPredictor(Predictor):
             go_fast = False
 
         model = self.fp8_model if go_fast else self.bf16_model
-        model.handle_loras(lora_weights, lora_scale, extra_lora, extra_lora_scale, hf_api_token=hf_api_token, civitai_api_token=civitai_api_token)
+        model.handle_loras(
+            lora_weights,
+            lora_scale,
+            extra_lora,
+            extra_lora_scale,
+            hf_api_token=hf_api_token,
+            civitai_api_token=civitai_api_token
+        )
 
         width, height = self.size_from_aspect_megapixels(aspect_ratio, megapixels)
         imgs, np_imgs = model.predict(

--- a/predict.py
+++ b/predict.py
@@ -563,7 +563,7 @@ class DevLoraPredictor(Predictor):
             extra_lora,
             extra_lora_scale,
             hf_api_token=hf_api_token,
-            civitai_api_token=civitai_api_token
+            civitai_api_token=civitai_api_token,
         )
 
         width, height = self.size_from_aspect_megapixels(aspect_ratio, megapixels)

--- a/predict.py
+++ b/predict.py
@@ -528,7 +528,7 @@ class DevLoraPredictor(Predictor):
         disable_safety_checker: bool = Inputs.disable_safety_checker,
         go_fast: bool = Inputs.go_fast_with_default(True),
         lora_weights: str  = Input(
-            description="Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet. For example, 'fofr/flux-pixar-cars'. Civit Loras may require a Civitai API token, which you can provide in the civitai_api_token input.",
+            description="Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>/<lora-weights-file.safetensors>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet, including signed URLs. For example, 'fofr/flux-pixar-cars'. Civit AI and HuggingFace LoRAs may require an API token to access, which you can provide in the `civitai_api_token` and `hf_api_token` inputs respectively.",
             default=None,
         ),
         lora_scale: float = Inputs.lora_scale,

--- a/predict.py
+++ b/predict.py
@@ -557,6 +557,12 @@ class DevLoraPredictor(Predictor):
             go_fast = False
 
         model = self.fp8_model if go_fast else self.bf16_model
+        # Ignore extra_lora if it is the same as lora_weights
+        if extra_lora is not None and lora_weights is not None:
+            if extra_lora.strip() == lora_weights.strip():
+                print(f"Warning: extra_lora '{extra_lora}' is the same as lora_weights. Ignoring extra_lora.")
+                extra_lora = None
+
         model.handle_loras(
             lora_weights,
             lora_scale,

--- a/predict.py
+++ b/predict.py
@@ -560,7 +560,9 @@ class DevLoraPredictor(Predictor):
         # Ignore extra_lora if it is the same as lora_weights
         if extra_lora is not None and lora_weights is not None:
             if extra_lora.strip() == lora_weights.strip():
-                print(f"Warning: extra_lora '{extra_lora}' is the same as lora_weights. Ignoring extra_lora.")
+                print(
+                    f"Warning: extra_lora '{extra_lora}' is the same as lora_weights. Ignoring extra_lora."
+                )
                 extra_lora = None
 
         model.handle_loras(

--- a/predict.py
+++ b/predict.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 import numpy as np
 from PIL import Image
 from typing import List
-from cog import BasePredictor, Input, Path  # type: ignore
+from cog import BasePredictor, Input, Path, Secret  # type: ignore
 from flux.util import (
     download_weights,
     load_ae,
@@ -527,7 +527,10 @@ class DevLoraPredictor(Predictor):
         output_quality: int = Inputs.output_quality,
         disable_safety_checker: bool = Inputs.disable_safety_checker,
         go_fast: bool = Inputs.go_fast_with_default(True),
-        lora_weights: str = Inputs.lora_weights,
+        lora_weights: str  = Input(
+            description="Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet. For example, 'fofr/flux-pixar-cars'. Civit Loras may require a Civitai API token, which you can provide in the civitai_api_token input.",
+            default=None,
+        ),
         lora_scale: float = Inputs.lora_scale,
         extra_lora: str = Input(
             description="Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet. For example, 'fofr/flux-pixar-cars'",
@@ -540,13 +543,21 @@ class DevLoraPredictor(Predictor):
             ge=-1,
         ),
         megapixels: str = Inputs.megapixels,
+        hf_api_token: Secret = Input(
+            description="HuggingFace API token. If you're using a hf lora that needs authentication, you'll need to provide an API token.",
+            default=None,
+        ),
+        civitai_api_token: Secret = Input(
+            description="Civitai API token. If you're using a civitai lora that needs authentication, you'll need to provide an API token.",
+            default=None,
+        ),
     ) -> List[Path]:
         if image and go_fast:
             print("img2img not supported with fp8 quantization; running with bf16")
             go_fast = False
 
         model = self.fp8_model if go_fast else self.bf16_model
-        model.handle_loras(lora_weights, lora_scale, extra_lora, extra_lora_scale)
+        model.handle_loras(lora_weights, lora_scale, extra_lora, extra_lora_scale, hf_api_token=hf_api_token, civitai_api_token=civitai_api_token)
 
         width, height = self.size_from_aspect_megapixels(aspect_ratio, megapixels)
         imgs, np_imgs = model.predict(

--- a/predict.py
+++ b/predict.py
@@ -528,7 +528,7 @@ class DevLoraPredictor(Predictor):
         disable_safety_checker: bool = Inputs.disable_safety_checker,
         go_fast: bool = Inputs.go_fast_with_default(True),
         lora_weights: str = Input(
-            description="Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>/<lora-weights-file.safetensors>, CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet, including signed URLs. For example, 'fofr/flux-pixar-cars'. Civit AI and HuggingFace LoRAs may require an API token to access, which you can provide in the `civitai_api_token` and `hf_api_token` inputs respectively.",
+            description="Load LoRA weights. Supports Replicate models in the format <owner>/<username> or <owner>/<username>/<version>, HuggingFace URLs in the format huggingface.co/<owner>/<model-name>[/<lora-weights-file.safetensors>], CivitAI URLs in the format civitai.com/models/<id>[/<model-name>], or arbitrary .safetensors URLs from the Internet, including signed URLs. For example, 'fofr/flux-pixar-cars'. Civit AI and HuggingFace LoRAs may require an API token to access, which you can provide in the `civitai_api_token` and `hf_api_token` inputs respectively.",
             default=None,
         ),
         lora_scale: float = Inputs.lora_scale,

--- a/safe-push-configs/dev-lora.yaml
+++ b/safe-push-configs/dev-lora.yaml
@@ -116,8 +116,6 @@ predict:
     fixed_inputs:
       lora_weights: fofr/flux-90s-power-rangers
       extra_lora: fofr/flux-80s-cyberpunk
-      hf_api_token: None
-      civitai_api_key: None
     iterations: 10
     prompt: |
       For the extra_lora input, here is a list of loras you can use:

--- a/safe-push-configs/dev-lora.yaml
+++ b/safe-push-configs/dev-lora.yaml
@@ -116,6 +116,8 @@ predict:
     fixed_inputs:
       lora_weights: fofr/flux-90s-power-rangers
       extra_lora: fofr/flux-80s-cyberpunk
+      hf_api_token: None
+      civitai_api_key: None
     iterations: 10
     prompt: |
       For the extra_lora input, here is a list of loras you can use:

--- a/weights.py
+++ b/weights.py
@@ -263,4 +263,4 @@ def make_huggingface_download_url(owner: str, model_name: str) -> str:
 def make_civitai_download_url(model_id: str, civitai_api_token: str | None = None) -> str:
     if civitai_api_token is None:
         return f"https://civitai.com/api/download/models/{model_id}?type=Model&format=SafeTensor"
-    return f"https://civitai.com/api/download/models/{model_id}?type=Model&format=SafeTensor&token={civitai_api_token}"
+    return f"https://civitai.com/api/download/models/{model_id}?type=Model&format=SafeTensor&token={civitai_api_token.get_secret_value()}"

--- a/weights.py
+++ b/weights.py
@@ -11,8 +11,6 @@ from collections import deque
 from io import BytesIO
 from pathlib import Path
 
-import requests
-import huggingface_hub
 from huggingface_hub import hf_hub_download, login
 
 DEFAULT_CACHE_BASE_DIR = Path("/src/weights-cache")
@@ -82,7 +80,7 @@ def download_weights(url: str, path: Path, hf_api_token: str | None = None, civi
         print("Attemptig to login to HuggingFace using provided token...")
         login(token=hf_api_token.get_secret_value())
         print("Login to HuggingFace successful!")
-        
+
     download_url = make_download_url(url, hf_api_token=hf_api_token, civitai_api_token=civitai_api_token)
     download_weights_url(download_url, path)
 

--- a/weights.py
+++ b/weights.py
@@ -142,7 +142,7 @@ def download_weights_url(url: str, path: Path, hf_api_token: str | None = None):
                     files = HfApi().list_repo_files(repo_id)
                     sft_files = [file for file in files if ".safetensors" in file]
                     if len(sft_files) == 1:
-                        hf_hub_download(repo_id=repo_id, filename=sft_files[0])
+                        lora_weights = sft_files[0]
                     else:
                         raise ValueError(
                             f"No *.safetensors file was explicitly specified from the HuggingFace repo {repo_id} and more than one *.safetensors file was found. Found: {[sft_file for sft_file in sft_files]}"
@@ -151,7 +151,6 @@ def download_weights_url(url: str, path: Path, hf_api_token: str | None = None):
                 safetensors_path = hf_hub_download(
                     repo_id=f"{owner}/{model_name}",
                     filename=lora_weights,
-                    # token=hf_api_token.get_secret_value() if hf_api_token is not None else None,
                 )
                 # Copy the downloaded file to the desired path
                 shutil.copy(Path(safetensors_path), path)
@@ -265,7 +264,7 @@ def download_safetensors(url: str, path: Path):
         raise RuntimeError(f"Failed to download safetensors file: {e}")
 
 
-def make_download_url(url: str, civitai_api_token: str | None = None) -> str:
+def make_download_url(url: str, civitai_api_token: Secret | None = None) -> str:
     if url.startswith("data:"):
         return url
     if m := re.match(

--- a/weights.py
+++ b/weights.py
@@ -138,14 +138,14 @@ def download_weights_url(url: str, path: Path, hf_api_token: str | None = None):
         try:
             with logged_in_to_huggingface(hf_api_token):
                 if lora_weights is None:
-                    api = HfApi()
-                    files = api.list_repo_files(repo_id)
+                    repo_id = f"{owner}/{model_name}"
+                    files = HfApi().list_repo_files(repo_id)
                     sft_files = [file for file in files if ".safetensors" in file]
                     if len(sft_files) == 1:
                         hf_hub_download(repo_id=repo_id, filename=sft_files[0])
                     else:
                         raise ValueError(
-                            f"No *.safetensors file was explicitly specified from the HuggingFace repo {repo_id} and more than one *.safetensors file was found. Found: {[stf_file for sft_file in sft_files]}"
+                            f"No *.safetensors file was explicitly specified from the HuggingFace repo {repo_id} and more than one *.safetensors file was found. Found: {[sft_file for sft_file in sft_files]}"
                         )
 
                 safetensors_path = hf_hub_download(

--- a/weights.py
+++ b/weights.py
@@ -281,7 +281,7 @@ def make_download_url(url: str, civitai_api_token: Secret | None = None) -> str:
         return make_civitai_download_url(model_id, civitai_api_token)
     if m := re.match(r"^((?:https?://)?civitai\.com/api/download/models/.*)$", url):
         return url
-    if m := re.match(r"^(https?://.*\.safetensors\?.*)$", url):
+    if m := re.match(r"^(https?://.*\.safetensors(\?.*)?)$", url):
         return url  # URL with query parameters, keep the whole url
     if m := re.match(r"^(?:https?://replicate.com/)?([^/]+)/([^/]+)/?$", url):
         owner, model_name = m.groups()

--- a/weights.py
+++ b/weights.py
@@ -296,7 +296,7 @@ def make_download_url(url: str, civitai_api_token: Secret | None = None) -> str:
 
     if "huggingface.co" in url:
         raise ValueError(
-            "Failed to parse HuggingFace URL. Expected huggingface.co/<owner>/<model-name>"
+            "Failed to parse HuggingFace URL. Expected huggingface.co/<owner>/<model-name>[/<lora-weights-file.safetensors>]"
         )
     if "civitai.com" in url:
         raise ValueError(
@@ -305,7 +305,7 @@ def make_download_url(url: str, civitai_api_token: Secret | None = None) -> str:
     raise ValueError(
         """Failed to parse URL. Expected either:
 * Replicate model in the format <owner>/<username> or <owner>/<username>/<version>
-* HuggingFace URL in the format huggingface.co/<owner>/<model-name>
+* HuggingFace URL in the format huggingface.co/<owner>/<model-name>[/<lora-weights-file.safetensors>]
 * CivitAI URL in the format civitai.com/models/<id>[/<model-name>]
 * Arbitrary .safetensors URLs from the Internet"""
     )

--- a/weights.py
+++ b/weights.py
@@ -282,8 +282,6 @@ def make_download_url(url: str, civitai_api_token: str | None = None) -> str:
         return make_civitai_download_url(model_id, civitai_api_token)
     if m := re.match(r"^((?:https?://)?civitai\.com/api/download/models/.*)$", url):
         return url
-    if m := re.match(r"^(https?://.*\.safetensors)(?:\?|$)", url):
-        return url  # might be signed, keep the whole url
     if m := re.match(r"^(https?://.*\.safetensors\?.*)$", url):
         return url  # URL with query parameters, keep the whole url
     if m := re.match(r"^(?:https?://replicate.com/)?([^/]+)/([^/]+)/?$", url):


### PR DESCRIPTION
Adds support for:
- CivitAI and HuggingFace API tokens via new `civitai_api_token` and `hf_api_token` input parameters
- Standardizes on using the `huggingFace_hub.hf_hub_download` method to download weights from HF. This is a breaking change as written and requires users to specify the *.safetensors file explicitly when targeting these files. Before the syntax was `<owner>/<model>` and now its `<owner>/<model>/<lora-weights-file.safetensors>`. This removes friction of targeting models with multiple sets of LoRA weights where before we would just throw a ValueError.